### PR TITLE
Refactor how the JavaScript files are obtained #minor

### DIFF
--- a/Dockerfile.rootfs
+++ b/Dockerfile.rootfs
@@ -9,9 +9,9 @@ RUN apt-get update -y && \
     apt-get clean
 
 RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb \
-      -O packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
-RUN rm packages-microsoft-prod.deb
+      -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb && \
+    rm packages-microsoft-prod.deb
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
@@ -41,6 +41,16 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     apt-get clean
 
+RUN mkdir -p /opt/nodejs && \
+    wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.xz \
+        -O - | tar -xJ -C /opt/nodejs --strip-components=1 && \
+    wget https://github.com/omegaup/karel.js/releases/download/v0.2.1/karel \
+        -O /opt/nodejs/karel.wasm && \
+    wget https://github.com/omegaup/karel.js/releases/download/v0.2.1/karel.js \
+        -O /opt/nodejs/karel.js && \
+    chmod +x /opt/nodejs/karel.wasm /opt/nodejs/karel.js && \
+    python3 -c 'import random; random.seed("Ω🔒"); open("/opt/nodejs/urandom", "wb").write(bytes(random.randint(0, 255) for _ in range(4096)))'
+
 RUN mkdir /src
 WORKDIR /src
 
@@ -58,12 +68,11 @@ RUN mv /var/lib/omegajail/root-openjdk/java-14-openjdk-amd64/lib/server/classes.
         /usr/lib/jvm/java-14-openjdk-amd64/lib/server/classes.jsa && \
     mv /var/lib/omegajail/root-openjdk/java.base.so \
         /usr/lib/jvm/java.base.so && \
-    mv /var/lib/omegajail/root-js /opt/nodejs && \
     mv /var/lib/omegajail/root-dotnet/Main.runtimeconfig.json \
         /var/lib/omegajail/root-dotnet/Release.rsp \
         /usr/share/dotnet/ && \
     ln -s /opt/nodejs/bin/node /usr/bin/node && \
-    ln -s /opt/nodejs/node_modules /usr/lib/node_modules && \
+    ln -s /opt/nodejs/lib/node_modules /usr/lib/node_modules && \
     rm -rf /var/lib/omegajail && \
     mkdir -p /var/lib/omegajail/root/dev/ && \
     cp /dev/null /var/lib/omegajail/root/dev/null

--- a/Makefile
+++ b/Makefile
@@ -124,14 +124,14 @@ gtest_main.o : googletest/googletest/src/gtest_main.cc
 	touch $@
 
 rootfs: .omegajail-builder-rootfs-setup.stamp ${BINARIES} tools/omegajail-setup ${POLICIES}
-	sudo rm -rf $@
+	sudo rm -rf $@ ".$@.tmp"
 	mkdir ".$@.tmp"
-	$(MAKE) DESTDIR=".$@.tmp" install || rm -rf ".$@.tmp"
+	$(MAKE) DESTDIR=".$@.tmp" install || (sudo rm -rf ".$@.tmp" ; exit 1)
 	docker run \
 		--rm \
 		--mount "type=bind,source=${PWD}/.$@.tmp,target=/var/lib/omegajail" \
 		omegaup/omegajail-builder-rootfs-setup /src/mkroot --no-link && \
-	mv ".$@.tmp" "$@" || rm -rf ".$@.tmp"
+	mv ".$@.tmp" "$@" || (sudo rm -rf ".$@.tmp" ; exit 1)
 
 .omegajail-builder-rootfs-build.stamp: ${MKROOT_SOURCE_FILES}
 	docker build \

--- a/policies/js.policy
+++ b/policies/js.policy
@@ -40,6 +40,7 @@ rt_sigprocmask: allow
 rt_sigreturn: allow
 set_robust_list: allow
 set_tid_address: allow
+sched_yield: allow
 
 # Environment
 clock_getres: allow

--- a/tools/mkroot
+++ b/tools/mkroot
@@ -316,32 +316,6 @@ class Chroot:
             f.write(contents)
         os.utime(self.__chroot_path(path), (0, 0))
 
-    def extract(self,
-                url: str,
-                skip_prefix: str = '',
-                exclude: Sequence[str] = (),
-                include: Optional[Sequence[str]] = None) -> None:
-        """Extracts a remote file into the chroot."""
-        remote_file = RemoteFile(url)
-        with tarfile.open(remote_file.path) as tar:
-            for member in tar.getmembers():
-                path = os.path.normpath(member.name)
-                if not path.startswith(skip_prefix):
-                    continue
-                path = self.mountpoint + path[len(skip_prefix):]
-                if any([path.startswith(e) for e in exclude]):
-                    continue
-                if include is not None and path not in include:
-                    continue
-                if member.issym():
-                    self.symlink(path, member.linkname)
-                elif member.isfile():
-                    self.mkdir(os.path.dirname(path))
-                    with open(self.__chroot_path(path), 'wb') as dst:
-                        shutil.copyfileobj(
-                            tar.extractfile(member), dst, member.size)
-                    os.chmod(self.__chroot_path(path), member.mode)
-
     # __enter__ and __exit__ are just provided to support with for clarity of code.
     def __enter__(self) -> 'Chroot':
         return self
@@ -675,27 +649,14 @@ def _main() -> None:
 
     with Chroot(os.path.join(args.target, 'root-js'), JS_ROOT,
                 link=args.link) as root:
-        root.extract(
-            'https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-x64.tar.xz',
-            skip_prefix='node-v12.17.0-linux-x64/',
-            include=[
-                os.path.join(JS_ROOT, 'LICENSE'),
-                os.path.join(JS_ROOT, 'bin/node')
-            ])
-        with RemoteFile(
-                'https://github.com/omegaup/karel.js/releases/download/v0.2.1/karel'
-        ) as remote_file:
-            root.install(
-                os.path.join(JS_ROOT, 'karel.wasm'), remote_file.path, mode=0o755)
-        with RemoteFile(
-                'https://github.com/omegaup/karel.js/releases/download/v0.2.1/karel.js'
-        ) as remote_file:
-            root.install(os.path.join(JS_ROOT, 'karel.js'), remote_file.path)
-
-        random.seed(b'\u03A9\u1F512')  # Ω🔒
-        root.write(
-            os.path.join(JS_ROOT, 'urandom'),
-            bytes(random.randint(0, 255) for _ in range(4096)))
+        for filename in (
+                '/opt/nodejs/urandom',
+                '/opt/nodejs/karel.js',
+                '/opt/nodejs/bin/node',
+                '/opt/nodejs/karel.wasm',
+                '/opt/nodejs/LICENSE',
+        ):
+            root.copyfromhost(filename, relative_to=JS_ROOT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change moves the JavaScript file obtention to the Dockerfile. This
simplifies mkroot a bit and makes it possible to run npm later to
install stuff.