### PR TITLE
Refactor how the Docker images are built  #minor

### DIFF
--- a/Dockerfile.rootfs
+++ b/Dockerfile.rootfs
@@ -54,28 +54,31 @@ RUN mkdir -p /opt/nodejs && \
 RUN mkdir /src
 WORKDIR /src
 
+FROM setup AS rootfs-setup
 COPY ./tools/mkroot ./tools/java.base.aotcfg ./tools/Main.runtimeconfig.json ./tools/Release.rsp /src/
 
-FROM setup AS build
+FROM rootfs-setup AS rootfs-build
 RUN /src/mkroot
-RUN rm -rf /src/ && mkdir /src
 
-FROM build AS runtime
+FROM setup AS runtime
 RUN wget --quiet https://github.com/omegaup/libinteractive/releases/download/v2.0.25/libinteractive.jar \
     -O /usr/share/java/libinteractive.jar
 
-RUN mv /var/lib/omegajail/root-openjdk/java-14-openjdk-amd64/lib/server/classes.jsa \
-        /usr/lib/jvm/java-14-openjdk-amd64/lib/server/classes.jsa && \
-    mv /var/lib/omegajail/root-openjdk/java.base.so \
-        /usr/lib/jvm/java.base.so && \
-    mv /var/lib/omegajail/root-dotnet/Main.runtimeconfig.json \
-        /var/lib/omegajail/root-dotnet/Release.rsp \
-        /usr/share/dotnet/ && \
-    ln -s /opt/nodejs/bin/node /usr/bin/node && \
+RUN ln -s /opt/nodejs/bin/node /usr/bin/node && \
     ln -s /opt/nodejs/lib/node_modules /usr/lib/node_modules && \
-    rm -rf /var/lib/omegajail && \
     mkdir -p /var/lib/omegajail/root/dev/ && \
     cp /dev/null /var/lib/omegajail/root/dev/null
+
+COPY --from=rootfs-build \
+         /var/lib/omegajail/root-openjdk/java-14-openjdk-amd64/lib/server/classes.jsa \
+         /usr/lib/jvm/java-14-openjdk-amd64/lib/server/classes.jsa
+COPY --from=rootfs-build \
+         /var/lib/omegajail/root-openjdk/java.base.so \
+         /usr/lib/jvm/java.base.so
+COPY --from=rootfs-build \
+         /var/lib/omegajail/root-dotnet/Main.runtimeconfig.json \
+         /var/lib/omegajail/root-dotnet/Release.rsp \
+         /usr/share/dotnet/
 
 COPY --from=omegaup/omegajail-builder-distrib /var/lib/omegajail/ /var/lib/omegajail
 RUN mv /var/lib/omegajail/bin/omegajail /var/lib/omegajail/bin/omegajail.wrapped

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ gtest_main.o : googletest/googletest/src/gtest_main.cc
 	docker build \
 		-t omegaup/omegajail-builder-rootfs-setup \
 		--file Dockerfile.rootfs \
-		--target setup \
+		--target rootfs-setup \
 		.
 	touch $@
 
@@ -137,7 +137,7 @@ rootfs: .omegajail-builder-rootfs-setup.stamp ${BINARIES} tools/omegajail-setup 
 	docker build \
 		-t omegaup/omegajail-builder-rootfs-build \
 		--file Dockerfile.rootfs \
-		--target build \
+		--target rootfs-build \
 		.
 	touch $@
 


### PR DESCRIPTION
It turns out that since Docker images are additive, and the runtime
container was depending on the container that runs mkroot, and that
generates _tons_ of files, the resulting container ended up having ~2x
the number of files, just to be deleted immediately in the runtime
container. This caused zero disk savings.

Now the container that runs mkroot is a completely separate one, so
there's no duplication in the runtime container!