### PR TITLE
Allow `ioctl` to use the `TIOCGWINSZ` flag

### DIFF
--- a/policies/gcc.policy
+++ b/policies/gcc.policy
@@ -12,7 +12,7 @@ close: allow
 {dup, dup2}: allow
 {fcntl[arch=x86_64], fcntl64[arch=armv7]}: arg1 == F_GETFL || arg1 == F_SETFD || arg1 == F_GETFD
 {fstat[arch=x86_64], fstat64[arch=armv7]}: allow
-ioctl: arg1 == TCGETS || arg1 == FIONBIO
+ioctl: arg1 == TCGETS || arg1 == FIONBIO || arg1 == TIOCGWINSZ
 {lseek, _llseek[arch=armv7]}: allow
 {lstat[arch=x86_64], lstat64[arch=armv7]}: allow
 openat: allow


### PR DESCRIPTION
This is needed for Rust compilation errors.