### PR TITLE
Add the `omegajail-cgroups-wrapper` binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -55,5 +55,6 @@
 !tools/mkroot
 !tools/omegajail-setup
 !tools/omegajail-container-wrapper
+!tools/omegajail-cgroups-wrapper
 !policies/*.policy
 !policies/*.frequency

--- a/Dockerfile.distrib
+++ b/Dockerfile.distrib
@@ -19,6 +19,7 @@ COPY ./cxxopts/include/ ./cxxopts/include/
 COPY ./minijail/ ./minijail/
 COPY Makefile *.h *.cpp ./
 COPY tools/omegajail-setup ./tools/
+COPY tools/omegajail-cgroups-wrapper ./tools/
 COPY ./policies/*.policy ./policies/*.frequency ./policies/
 
 ARG OMEGAJAIL_RELEASE

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ policies/%.bpf: policies/%.policy policies/omegajail.policy | minijail/constants
 install: ${BINARIES} tools/omegajail-setup ${POLICIES}
 	install -d $(DESTDIR)/bin
 	install -t $(DESTDIR)/bin ${BINARIES} tools/omegajail-setup
+	install -t $(DESTDIR)/bin ${BINARIES} tools/omegajail-cgroups-wrapper
 	install -d $(DESTDIR)/policies
 	install -t $(DESTDIR)/policies -m 0644 ${POLICIES}
 

--- a/tools/omegajail-cgroups-wrapper
+++ b/tools/omegajail-cgroups-wrapper
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Wraps the original omegaup runner binary to set its cgroups up.
+
+set -e
+
+if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
+  mkdir -p "/sys/fs/cgroup/system.slice/omegaup-runner.service"/{omegaup-runner,omegajail}
+
+  # Move the process to another group to avoid violating the "no processes in
+  # intermediate nodes" rule.
+  echo $$ > "/sys/fs/cgroup/system.slice/omegaup-runner.service/omegaup-runner/cgroup.procs"
+  # Delegate the memory subtree control for both the OG cgroup and the one where
+  # all the omegajail processes will live in.
+  echo '+memory' > "/sys/fs/cgroup/system.slice/omegaup-runner.service/cgroup.subtree_control"
+  echo '+memory' > "/sys/fs/cgroup/system.slice/omegaup-runner.service/omegajail/cgroup.subtree_control"
+else
+  mkdir -p "/sys/fs/cgroup/memory/system.slice/omegaup-runner.service"/{omegaup-runner,omegajail}
+
+  # Move the process to another group to avoid violating the "no processes in
+  # intermediate nodes" rule.
+  echo $$ > "/sys/fs/cgroup/memory/system.slice/omegaup-runner.service/omegaup-runner/cgroup.procs"
+fi
+
+# Now that all the cgroups are set, let's start the process.
+exec "$@"

--- a/tools/omegajail-setup
+++ b/tools/omegajail-setup
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-# Performs per-boot setup of the environment needed for omegajail.
+# Performs setup of the omegaup cgroups needed for omegajail.
 # Should be run as root.
 
 set -e
 
-# Create a memory cgroup and make omegaup an admin.
-/bin/mkdir -p -m 0775 /sys/fs/cgroup/memory/omegajail
-/bin/chgrp omegaup /sys/fs/cgroup/memory/omegajail
+# Make omegup the admin of the delegated memory cgroup.
+if [[ ! -f /sys/fs/cgroup/cgroup.controllers ]]; then
+  chown omegaup:omegaup -R /sys/fs/cgroup/memory/system.slice/omegaup-runner.service
+fi


### PR DESCRIPTION
This change adds a new binary that can be called before the
`omegaup-runner` such that it hs the correct cgroups setup for calling
omegajail, in either cgroups v1 or v2.