### PR TITLE
Fix the display of the errnos

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// negative, and the result of the function as-is otherwise.
 fn check_err(num: libc::c_long) -> Result<libc::c_long> {
     if num < 0 {
-        match Errno::from_i32(num.try_into()?) {
+        match Errno::from_i32(-num.try_into()?) {
             Errno::UnknownErrno => {
                 bail!("unknown errno: {}", num);
             }


### PR DESCRIPTION
Turns out that we were getting a negative error number, but all the errnos are positive! This change fixes that.