### PR TITLE
Update JavaScript runtime to Node 22

### DIFF
--- a/Dockerfile.rootfs
+++ b/Dockerfile.rootfs
@@ -62,7 +62,7 @@ RUN for i in 1 2 3; do \
     apt-get clean
 
 RUN mkdir -p /opt/nodejs && \
-    wget https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz \
+    wget https://nodejs.org/dist/v22.22.0/node-v22.22.0-linux-x64.tar.xz \
         -O - | tar -xJ -C /opt/nodejs --strip-components=1 && \
     mkdir -p /opt/go && \
     wget https://go.dev/dl/go1.18beta2.linux-amd64.tar.gz \

--- a/policies/js.policy
+++ b/policies/js.policy
@@ -22,6 +22,10 @@ readlink: allow
 {statx[arch=x86_64], statx64[arch=armv7]}: allow
 socket: return ENETDOWN
 
+# Kernel feature probes
+io_uring_setup: return ENOSYS
+sysinfo: return ENOSYS
+
 # Memory
 {arch_prctl[arch=x86_64], ARM_set_tls[arch=armv7]}: allow
 brk: allow
@@ -43,9 +47,11 @@ rt_sigreturn: allow
 set_robust_list: allow
 set_tid_address: allow
 rseq: allow
+sched_getaffinity: allow
 sched_yield: allow
 
 # Environment
+capget: allow
 clock_getres: allow
 {getegid[arch=x86_64], getegid32[arch=armv7]}: allow
 {geteuid[arch=x86_64], geteuid32[arch=armv7]}: allow


### PR DESCRIPTION
## Changes

- Upgrade the JS runtime from Node 16.13.1 to Node 22.22.0.
- Update `policies/js.policy` for Node 22 syscalls:
  - Allow `capget` and `sched_getaffinity`.
  - Return `ENOSYS` for `io_uring_setup` and `sysinfo`.

## Validation

- `make out/policies/js.bpf out/policies/sigsys/js.bpf`
- `cargo fmt --check`
- `make smoketest-docker`
- `docker run ... /src/test --languages js,kj,kp --strace`

`js`, `kj`, and `kp` pass with Node 22.

Fixes: #55 