### PR TITLE
Strengthen ReKarel smoke regressions

### DIFF
--- a/smoketest/input-karel-instruction-limit
+++ b/smoketest/input-karel-instruction-limit
@@ -1,0 +1,16 @@
+<ejecucion>
+	<condiciones instruccionesMaximasAEjecutar="20" longitudStack="65000"></condiciones>
+	<mundos>
+		<mundo nombre="mundo_0" ancho="100" alto="100">
+			<monton x="1" y="1" zumbadores="2"></monton>
+			<monton x="2" y="1" zumbadores="3"></monton>
+			<posicionDump x="1" y="1"></posicionDump>
+			<posicionDump x="2" y="1"></posicionDump>
+		</mundo>
+	</mundos>
+	<programas tipoEjecucion="CONTINUA" intruccionesCambioContexto="1" milisegundosParaPasoAutomatico="0">
+		<programa nombre="p1" ruta="{$2$}" mundoDeEjecucion="mundo_0" xKarel="1" yKarel="1" direccionKarel="NORTE" mochilaKarel="0">
+			<despliega tipo="MUNDO"></despliega>
+		</programa>
+	</programas>
+</ejecucion>

--- a/smoketest/rekarel-ce.rk
+++ b/smoketest/rekarel-ce.rk
@@ -1,0 +1,6 @@
+class program {
+    program () {
+        turnleft(
+        turnoff();
+    }
+}

--- a/smoketest/rekarel-ile.rk
+++ b/smoketest/rekarel-ile.rk
@@ -1,0 +1,8 @@
+class program {
+    program () {
+        while (nextToABeeper()) {
+            turnleft();
+        }
+        turnoff();
+    }
+}

--- a/smoketest/sumas.rk
+++ b/smoketest/sumas.rk
@@ -1,25 +1,22 @@
-class program {
-    program () {
-        // toma todos los zumbadores de la celda de la derecha.
-        turnleft();
-        turnleft();
-        turnleft();
-        move();
-        turnleft();
-        while (nextToABeeper()) {
-          pickbeeper();
-        }
+iniciar-programa
+    inicia-ejecucion
+        { rk debe poder detectar sintaxis Pascal en un archivo .rk }
+        gira-izquierda;
+        gira-izquierda;
+        gira-izquierda;
+        avanza;
+        gira-izquierda;
+        mientras junto-a-zumbador hacer
+            coge-zumbador;
 
-        // deja todos los zumbadores de la mochila
-        turnleft();
-        move();
-        turnleft();
-        turnleft();
-        turnleft();
-        while (anyBeepersInBeeperBag()) {
-          putbeeper();
-        }
+        gira-izquierda;
+        avanza;
+        gira-izquierda;
+        gira-izquierda;
+        gira-izquierda;
+        mientras algun-zumbador-en-la-mochila hacer
+            deja-zumbador;
 
-        turnoff();
-    }
-}
+        apagate;
+    termina-ejecucion
+finalizar-programa

--- a/smoketest/test
+++ b/smoketest/test
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 _LANGUAGES: List[str] = [
     'c',
@@ -62,7 +62,7 @@ _KAREL_LANGUAGES: Set[str] = set(['kj', 'kp', 'rk'])
 _PWD = os.path.abspath(os.path.dirname(__file__))
 
 
-def _check_call(args: List[str]) -> bool:
+def _check_call(args: List[str], expect_success: bool = True) -> bool:
     try:
         command = ' '.join(shlex.quote(arg) for arg in args)
         logging.debug("calling '%s'", command)
@@ -70,8 +70,25 @@ def _check_call(args: List[str]) -> bool:
         return True
     except subprocess.CalledProcessError:
         command = ' '.join(shlex.quote(arg) for arg in args)
-        logging.error("Failed to run '%s'", command)
+        if expect_success:
+            logging.error("Failed to run '%s'", command)
+        else:
+            logging.debug("Command failed as expected: '%s'", command)
         return False
+
+
+def _file_contains(path: str, needle: str) -> bool:
+    try:
+        with open(path, 'r', encoding='utf-8') as contents:
+            haystack = contents.read()
+    except OSError as err:
+        logging.error("Failed to read %r: %s", path, err)
+        return False
+    if needle not in haystack:
+        logging.error("%r does not contain %r. got %r", path, needle,
+                      haystack)
+        return False
+    return True
 
 
 def _omegajail_compile(
@@ -80,16 +97,20 @@ def _omegajail_compile(
     strace: bool,
     cgroup_path: str,
     disable_sandboxing: bool = False,
+    case_name: Optional[str] = None,
+    source_path: Optional[str] = None,
+    source_name: Optional[str] = None,
+    output_limit: int = 10485100,
+    expect_success: bool = True,
 ) -> bool:
-    lang_dir = os.path.join(_PWD, 'run', lang)
+    lang_dir = os.path.join(_PWD, 'run', case_name or lang)
     if os.path.isdir(lang_dir):
         shutil.rmtree(lang_dir, True)
     os.makedirs(lang_dir)
     target = 'Main'
-    source = f'{target}.{_EXTENSIONS.get(lang, lang)}'
-    os.link(
-        os.path.join(_PWD, f'sumas.{lang}'),
-        os.path.join(lang_dir, source))
+    source = source_name or f'{target}.{_EXTENSIONS.get(lang, lang)}'
+    os.link(source_path or os.path.join(_PWD, f'sumas.{lang}'),
+            os.path.join(lang_dir, source))
     if strace:
         args = [
             'strace', '-f', '-o',
@@ -112,7 +133,7 @@ def _omegajail_compile(
         '-t',
         '30000',
         '-O',
-        '10485100',
+        str(output_limit),
         '--root',
         root,
         '--compile',
@@ -132,7 +153,7 @@ def _omegajail_compile(
     if lang == 'cs':
         os.symlink('/usr/lib/dotnet/Main.runtimeconfig.json',
                    os.path.join(lang_dir, 'Main.runtimeconfig.json'))
-    return _check_call(args)
+    return _check_call(args, expect_success=expect_success)
 
 
 def _omegajail_run(
@@ -140,11 +161,17 @@ def _omegajail_run(
     lang: str,
     strace: bool,
     input_path: str,
-    output_path: str,
+    output_path: Optional[str],
     cgroup_path: str,
     disable_sandboxing: bool = False,
+    case_name: Optional[str] = None,
+    time_limit: int = 3000,
+    wall_time_limit: int = 3000,
+    output_limit: int = 1048510,
+    memory_limit: int = 256 * 1024 * 1024,
+    expect_success: bool = True,
 ) -> bool:
-    lang_dir = os.path.join(_PWD, 'run', lang)
+    lang_dir = os.path.join(_PWD, 'run', case_name or lang)
     if strace:
         args = [
             'strace', '-f', '-o',
@@ -166,13 +193,13 @@ def _omegajail_run(
         '-M',
         os.path.join(lang_dir, 'run.meta'),
         '-t',
-        '3000',
+        str(time_limit),
         '-w',
-        '3000',
+        str(wall_time_limit),
         '-O',
-        '1048510',
+        str(output_limit),
         '-m',
-        str(256 * 1024 * 1024),
+        str(memory_limit),
         '--root',
         root,
         '--run',
@@ -187,8 +214,10 @@ def _omegajail_run(
     if disable_sandboxing:
         args.append('--disable-sandboxing')
 
-    if not _check_call(args):
+    if not _check_call(args, expect_success=expect_success):
         return False
+    if output_path is None:
+        return True
     with open(
         os.path.join(lang_dir, 'run.out'), 'r', encoding='utf-8') as run_out:
         got = run_out.read().strip()
@@ -199,6 +228,101 @@ def _omegajail_run(
         logging.error("Wrong answer when running '%s'. got %r, expected %r",
                      lang, got, expected)
     return got == expected
+
+
+def _run_rekarel_regressions(
+    root: str,
+    strace: bool,
+    cgroup_path: str,
+    disable_sandboxing: bool,
+) -> bool:
+    passed = True
+
+    case_name = 'rk-ce'
+    if _omegajail_compile(
+            root=root,
+            lang='rk',
+            strace=strace,
+            cgroup_path=cgroup_path,
+            disable_sandboxing=disable_sandboxing,
+            case_name=case_name,
+            source_path=os.path.join(_PWD, 'rekarel-ce.rk'),
+            source_name='Main.rk',
+            expect_success=False,
+    ):
+        logging.error("Expected ReKarel syntax error to fail compilation")
+        passed = False
+    else:
+        passed &= _file_contains(
+            os.path.join(_PWD, 'run', case_name, 'compile.meta'), 'status:1')
+
+    case_name = 'rk-ile'
+    if _omegajail_compile(
+            root=root,
+            lang='rk',
+            strace=strace,
+            cgroup_path=cgroup_path,
+            disable_sandboxing=disable_sandboxing,
+            case_name=case_name,
+            source_path=os.path.join(_PWD, 'rekarel-ile.rk'),
+            source_name='Main.rk',
+    ):
+        if _omegajail_run(
+                root=root,
+                lang='rk',
+                strace=strace,
+                input_path='input-karel-instruction-limit',
+                output_path=None,
+                cgroup_path=cgroup_path,
+                disable_sandboxing=disable_sandboxing,
+                case_name=case_name,
+                expect_success=False,
+        ):
+            logging.error("Expected ReKarel infinite loop to hit ILE")
+            passed = False
+        else:
+            passed &= _file_contains(
+                os.path.join(_PWD, 'run', case_name, 'run.meta'),
+                'status:1')
+            passed &= _file_contains(
+                os.path.join(_PWD, 'run', case_name, 'run.out'),
+                'resultadoEjecucion="LIMITE DE INSTRUCCIONES"')
+    else:
+        passed = False
+
+    case_name = 'rk-ole'
+    if _omegajail_compile(
+            root=root,
+            lang='rk',
+            strace=strace,
+            cgroup_path=cgroup_path,
+            disable_sandboxing=disable_sandboxing,
+            case_name=case_name,
+            source_path=os.path.join(_PWD, 'sumas.rk'),
+            source_name='Main.rk',
+    ):
+        if _omegajail_run(
+                root=root,
+                lang='rk',
+                strace=strace,
+                input_path='input-karel',
+                output_path=None,
+                cgroup_path=cgroup_path,
+                disable_sandboxing=disable_sandboxing,
+                case_name=case_name,
+                output_limit=16,
+                expect_success=False,
+        ):
+            logging.error("Expected ReKarel output limit case to fail")
+            passed = False
+        else:
+            passed &= _file_contains(
+                os.path.join(_PWD, 'run', case_name, 'run.meta'),
+                'signal:SIGXFSZ')
+    else:
+        passed = False
+
+    return passed
 
 
 def _main() -> None:
@@ -269,6 +393,19 @@ def _main() -> None:
                 strace=args.strace,
                 input_path=input_path,
                 output_path=output_path,
+                cgroup_path=args.cgroup_path,
+                disable_sandboxing=args.disable_sandboxing,
+        ):
+            print('OK')
+        else:
+            print('ERROR')
+            passed = False
+
+    if 'rk' in languages:
+        print(f'{"rk-regressions":<20}', end='')
+        if _run_rekarel_regressions(
+                root=args.root,
+                strace=args.strace,
                 cgroup_path=args.cgroup_path,
                 disable_sandboxing=args.disable_sandboxing,
         ):


### PR DESCRIPTION
Strengthens ReKarel smoke coverage and keeps `kj`/`kp` in the normal matrix.

Changes:

- Updates `sumas.rk` to use Pascal syntax under a `.rk` file, exercising ReKarel language detection.
- Adds a ReKarel CE regression for syntax errors.
- Adds a ReKarel ILE regression for infinite loops via a low instruction limit.
- Adds a ReKarel OLE regression via a low output limit.
- Runs the ReKarel regression group whenever `rk` is included in `smoketest/test`.

MLE is not added because there is no deterministic ReKarel-specific memory stress case in the current smoke harness, and the issue marks it as “if applies”.

Validation:

- `python3 -m py_compile smoketest/test`
- `docker run ... /usr/bin/python3 /src/test --languages kj,kp,rk`
- `make smoketest-docker`

Fixes #54.
