### PR TITLE
Add ReKarel Java syntax smoketest

### DIFF
--- a/smoketest/rekarel-java.rk
+++ b/smoketest/rekarel-java.rk
@@ -1,0 +1,24 @@
+class program {
+    program () {
+        // rk should detect Java-style Karel syntax in a .rk file.
+        turnleft();
+        turnleft();
+        turnleft();
+        move();
+        turnleft();
+        while (nextToABeeper()) {
+            pickbeeper();
+        }
+
+        turnleft();
+        move();
+        turnleft();
+        turnleft();
+        turnleft();
+        while (anyBeepersInBeeperBag()) {
+            putbeeper();
+        }
+
+        turnoff();
+    }
+}

--- a/smoketest/test
+++ b/smoketest/test
@@ -238,6 +238,30 @@ def _run_rekarel_regressions(
 ) -> bool:
     passed = True
 
+    case_name = 'rk-java'
+    if _omegajail_compile(
+            root=root,
+            lang='rk',
+            strace=strace,
+            cgroup_path=cgroup_path,
+            disable_sandboxing=disable_sandboxing,
+            case_name=case_name,
+            source_path=os.path.join(_PWD, 'rekarel-java.rk'),
+            source_name='Main.rk',
+    ):
+        passed &= _omegajail_run(
+            root=root,
+            lang='rk',
+            strace=strace,
+            input_path='input-karel',
+            output_path='output-karel',
+            cgroup_path=cgroup_path,
+            disable_sandboxing=disable_sandboxing,
+            case_name=case_name,
+        )
+    else:
+        passed = False
+
     case_name = 'rk-ce'
     if _omegajail_compile(
             root=root,


### PR DESCRIPTION
## Description

Adds a positive ReKarel smoke regression that compiles and runs Java-style Karel syntax from a `.rk` file.

This complements the existing `sumas.rk` case, which exercises Pascal-style syntax detection for `rk`.

## Related Issue

Follow-up to #54

## Testing

- `python3 -m py_compile smoketest/test`
- Docker smoketest for `rk`
- Full Docker smoketest