### PR TITLE
Publish runtime image to GHCR #minor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,8 @@ jobs:
           fi
 
       - name: Upload artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v5
+        if: ${{ always() && hashFiles('smoketest/run/**') != '' }}
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs
           path: smoketest/run/
@@ -122,8 +122,8 @@ jobs:
           }
 
       - name: Upload artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v5
+        if: ${{ always() && hashFiles('smoketest/run/**') != '' }}
+        uses: actions/upload-artifact@v7
         with:
           name: test-logs-docker
           path: smoketest/run/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        if: ${{ always() && hashFiles('smoketest/run/**') != '' }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: test-logs
@@ -122,7 +122,7 @@ jobs:
           }
 
       - name: Upload artifacts
-        if: ${{ always() && hashFiles('smoketest/run/**') != '' }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: test-logs-docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
 
   release:
@@ -74,7 +78,7 @@ jobs:
         if: ${{ steps.bump-version.outputs.part == 'major' || steps.bump-version.outputs.part == 'minor' }}
         run: |
           echo "${{ github.token }}" | \
-              docker login https://docker.pkg.github.com "--username=${{ github.actor }}" --password-stdin
-          container_name=docker.pkg.github.com/${{ github.repository }}/omegajail-builder-rootfs-runtime:${{ steps.bump-version.outputs.tag }}
+              docker login ghcr.io "--username=${{ github.actor }}" --password-stdin
+          container_name=ghcr.io/${{ github.repository }}/omegajail-builder-rootfs-runtime:${{ steps.bump-version.outputs.tag }}
           docker tag omegaup/omegajail-builder-rootfs-runtime "${container_name}"
           docker push "${container_name}"


### PR DESCRIPTION
## Description

- Adds explicit release workflow permissions for GitHub releases and packages.
- Publishes `omegajail-builder-rootfs-runtime` to GHCR on major/minor releases.
- Keeps the existing major/minor gate for runtime/rootfs image publication.

This matches the image registry consumed by downstream runner images such as `quark`.

