### PR TITLE
Make release workflow explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
+  workflow_dispatch: {}
   push:
-    branches:
-      - main
     tags:
       - v*
 


### PR DESCRIPTION
## Summary

Make the release workflow explicit by removing the automatic `main` branch trigger.

Releases can still be started manually through `workflow_dispatch` or by pushing a `v*` tag. This prevents normal merges to `main` from accidentally publishing a patch release while the Rust binary version metadata is still being audited.

Fixes: #63 
