### PR TITLE
Fix seccomp user notification exit hang

### DIFF
--- a/policies/base/omegajail.policy
+++ b/policies/base/omegajail.policy
@@ -1,2 +1,3 @@
 execve: allow
 sendmsg: allow
+sendto: arg4 == 0 && arg5 == 0

--- a/src/jail/child_init.rs
+++ b/src/jail/child_init.rs
@@ -34,6 +34,14 @@ use crate::sys::{
 // Used to pass None to nix::mount::mount
 const NONE: Option<&'static [u8]> = None;
 
+#[derive(Debug, PartialEq, Eq)]
+enum SeccompEpollAction {
+    ChildExited,
+    ReadSeccompNotification,
+    SeccompFdError,
+    Continue,
+}
+
 pub(crate) fn run(mut parent_jail_sock: UnixStream, opts: JailOptions) -> Result<()> {
     set_cpu_affinity().context("set cpu affinity")?;
 
@@ -487,10 +495,11 @@ fn wait_read_seccomp_notification(
             }
             Ok(nfds) => nfds,
         };
-        for i in 0..nfds {
-            if events[i].data() == child_pidfd.as_raw_fd().try_into()? {
+        match seccomp_epoll_action(&events[..nfds], child_pidfd.as_raw_fd(), seccomp_fd) {
+            SeccompEpollAction::ChildExited => {
                 return Ok(None);
-            } else {
+            }
+            SeccompEpollAction::ReadSeccompNotification => {
                 let notification =
                     seccomp_read_notification(seccomp_fd, &mut notification_contents)
                         .context("seccomp_read_notification")?;
@@ -506,6 +515,115 @@ fn wait_read_seccomp_notification(
                     }
                 }
             }
+            SeccompEpollAction::SeccompFdError => {
+                bail!("seccomp fd reported an error");
+            }
+            SeccompEpollAction::Continue => {}
         }
+    }
+}
+
+fn seccomp_epoll_action(
+    events: &[EpollEvent],
+    child_pidfd: RawFd,
+    seccomp_fd: RawFd,
+) -> SeccompEpollAction {
+    let child_pidfd_data = child_pidfd as u64;
+    if events.iter().any(|event| event.data() == child_pidfd_data) {
+        return SeccompEpollAction::ChildExited;
+    }
+
+    if seccomp_fd < 0 {
+        return SeccompEpollAction::Continue;
+    }
+
+    let seccomp_fd_data = seccomp_fd as u64;
+    for event in events
+        .iter()
+        .filter(|event| event.data() == seccomp_fd_data)
+    {
+        let flags = event.events();
+        if flags.contains(EpollFlags::EPOLLERR) {
+            return SeccompEpollAction::SeccompFdError;
+        }
+        if flags.contains(EpollFlags::EPOLLHUP) {
+            return SeccompEpollAction::ChildExited;
+        }
+        if flags.contains(EpollFlags::EPOLLIN) {
+            return SeccompEpollAction::ReadSeccompNotification;
+        }
+    }
+
+    SeccompEpollAction::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seccomp_epoll_action_prioritizes_child_exit() {
+        let events = [
+            EpollEvent::new(EpollFlags::EPOLLIN, 0),
+            EpollEvent::new(EpollFlags::EPOLLIN, 5),
+        ];
+
+        assert_eq!(
+            SeccompEpollAction::ChildExited,
+            seccomp_epoll_action(&events, 5, 0)
+        );
+    }
+
+    #[test]
+    fn test_seccomp_epoll_action_reads_only_on_seccomp_input() {
+        let events = [EpollEvent::new(EpollFlags::EPOLLIN, 0)];
+
+        assert_eq!(
+            SeccompEpollAction::ReadSeccompNotification,
+            seccomp_epoll_action(&events, 5, 0)
+        );
+    }
+
+    #[test]
+    fn test_seccomp_epoll_action_treats_seccomp_hangup_as_exit() {
+        let events = [EpollEvent::new(EpollFlags::EPOLLHUP, 0)];
+
+        assert_eq!(
+            SeccompEpollAction::ChildExited,
+            seccomp_epoll_action(&events, 5, 0)
+        );
+    }
+
+    #[test]
+    fn test_seccomp_epoll_action_prioritizes_hangup_over_input() {
+        let events = [EpollEvent::new(
+            EpollFlags::EPOLLIN | EpollFlags::EPOLLHUP,
+            0,
+        )];
+
+        assert_eq!(
+            SeccompEpollAction::ChildExited,
+            seccomp_epoll_action(&events, 5, 0)
+        );
+    }
+
+    #[test]
+    fn test_seccomp_epoll_action_treats_seccomp_error_as_error() {
+        let events = [EpollEvent::new(EpollFlags::EPOLLERR, 0)];
+
+        assert_eq!(
+            SeccompEpollAction::SeccompFdError,
+            seccomp_epoll_action(&events, 5, 0)
+        );
+    }
+
+    #[test]
+    fn test_seccomp_epoll_action_ignores_unknown_events() {
+        let events = [EpollEvent::new(EpollFlags::EPOLLIN, 7)];
+
+        assert_eq!(
+            SeccompEpollAction::Continue,
+            seccomp_epoll_action(&events, 5, 0)
+        );
     }
 }

--- a/src/jail/mod.rs
+++ b/src/jail/mod.rs
@@ -450,6 +450,20 @@ mod tests {
     }
 
     #[test]
+    fn test_exit() -> Result<()> {
+        init();
+        run_test_case(TestCase {
+            widget: "exit",
+            stdin: "",
+            stdout: Some(""),
+            stderr: Some(""),
+            ..TestCase::default()
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
     fn test_stdio() -> Result<()> {
         init();
         run_test_case(TestCase {

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -14,6 +14,8 @@ const NONE: Option<&'static [u8]> = None;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ArgEnum)]
 enum Widget {
+    /// Exit immediately.
+    Exit,
     /// Basic stdio test.
     Stdio,
     /// Ensure that only file descriptors 1-3 are accessible.
@@ -43,6 +45,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     match args.widget {
+        Widget::Exit => {}
         Widget::Stdio => {
             let mut stdin_buf = String::new();
             stdin().read_to_string(&mut stdin_buf)?;


### PR DESCRIPTION
## Summary

Fix a seccomp user-notification hang observed on Ubuntu 22.04 with Azure kernel 6.8.

The sandbox supervisor could block in `SECCOMP_IOCTL_NOTIF_RECV` after the sandboxed process had already exited. The fix makes the epoll handling prioritize child `pidfd` readiness, treats seccomp `EPOLLHUP` as child exit, and only calls `SECCOMP_IOCTL_NOTIF_RECV` when the seccomp fd has real input readiness.

This also adds a restricted base-policy `sendto` rule needed during the seccomp listener handoff:
```yaml
    sendto: arg4 == 0 && arg5 == 0
```

Fixes: #64 

## Validation

Validated on the Azure pre-canary environment where the hang originally reproduced:

- Ubuntu 22.04
- Azure kernel `6.8.0-1065-azure`
- delegated cgroup v2 path through systemd
- cpp11 compile exited `0`
- `Main` ELF was produced
- `compile.meta` contained `status:0`
- no `SIGSYS`
- no omegaJail/g++/cc1plus/collect2 processes remained
- delayed validation showed no zombies or remaining processes

The only `compile.err` output was the known benign `KernelSiginfo` INFO message.

Local checks:

- `cargo fmt --check`
- `cargo test jail::child_init::tests -- --nocapture`
- `cargo test jail::tests::test_exit -- --nocapture`
- `git diff --check`

## Notes

This intentionally uses the restricted rule `sendto: arg4 == 0 && arg5 == 0` instead of broad `sendto: allow`.