### PR TITLE
Allow faccessat2 in GCC seccomp policy

### DIFF
--- a/policies/gcc.policy
+++ b/policies/gcc.policy
@@ -11,6 +11,7 @@ chmod: allow
 close: allow
 {dup, dup2}: allow
 faccessat: allow
+faccessat2: allow
 {fcntl[arch=x86_64], fcntl64[arch=armv7]}: arg1 == F_GETFL || arg1 == F_SETFD || arg1 == F_GETFD || arg1 == F_SETFL
 {fstat[arch=x86_64], fstat64[arch=armv7]}: allow
 ioctl: arg1 == TCGETS || arg1 == FIONBIO || arg1 == TIOCGWINSZ


### PR DESCRIPTION
## Summary

Allow `faccessat2` in the GCC seccomp policy for Ubuntu 22.04 / Jammy.

`g++-11` can use `faccessat2` during cpp11 compilation. Without this rule, omegaJail reports `SIGSYS` for syscall `faccessat2`.

Fixes: #65 

## Validation

- `make out/policies/gcc.bpf out/policies/sigsys/gcc.bpf`
- Validated in Azure pre-canary: cpp11 compilation exited `0`, produced `Main`, and `compile.meta` contained `status:0`.