### PR TITLE
Restore sandboxed Rust tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,20 +30,15 @@ jobs:
           cargo build --bins
           cargo build --tests
 
-      - name: Test
+      - name: Test non-jail cases
         run: |
-          # Hosted Jammy runners expose cgroup v2 and these jail cases have
-          # been observed to hang there. Keep them enabled in the test suite,
-          # but skip known hosted-runner cases here; sandbox-specific coverage
-          # still depends on local/suitable hosts because smoketest-docker runs
-          # through the container wrapper with --disable-sandboxing.
-          cargo test -- \
-            --skip jail::tests::test_stdio \
-            --skip jail::tests::test_file_descriptors \
-            --skip jail::tests::test_abort \
-            --skip jail::tests::test_oom \
-            --skip jail::tests::test_sigxfsz \
-            --skip jail::tests::test_sigxcpu
+          timeout 180s cargo test -- --skip 'jail::tests::'
+
+      - name: Test jail cases
+        run: |
+          # These tests create real sandboxes. Run them serially so cargo test
+          # does not interleave multiple namespace/cgroup/seccomp supervisors.
+          timeout 180s cargo test 'jail::tests::' -- --test-threads=1 --nocapture
 
       - name: Build rootfs
         run: make OMEGAJAIL_RELEASE=${{ github.sha }} rootfs

--- a/src/jail/mod.rs
+++ b/src/jail/mod.rs
@@ -300,9 +300,9 @@ impl Jail {
     }
 }
 
-// Some CI environments cannot run every jail unit test reliably because they
-// lack the namespace/cgroup behavior required by the sandbox. Keep the tests
-// enabled for local/suitable hosts; the workflow skips known hosted-runner cases.
+// These tests create real sandboxes. CI runs them in a separate serial step so
+// they keep exercising namespace/cgroup/seccomp behavior without being
+// interleaved by the Rust test harness.
 #[cfg(test)]
 mod tests {
     use std::ffi::CString;


### PR DESCRIPTION
## Summary

Restore the sandboxed Rust tests in CI.

Instead of skipping individual `jail::tests::*` cases on Jammy, the workflow now runs:

- non-jail tests separately
- jail tests in a dedicated serial step

The serial jail step avoids interleaving multiple namespace/cgroup/seccomp supervisors while still keeping coverage enabled in CI.

Fixes: #66 

## Validation

- `git diff --check`
- `cargo fmt --check`
- `timeout 180s cargo test -- --skip 'jail::tests::'`
- `timeout 180s cargo test 'jail::tests::' -- --test-threads=1 --nocapture`

The jail test command passed locally outside the Codex sandbox with 9/9 tests passing.