### PR TITLE
Fix Rust binary version metadata

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,6 +47,7 @@
 
 !Cargo.lock
 !Cargo.toml
+!build.rs
 !README.md
 !policies/*.frequency
 !policies/*.policy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "omegajail"
-version = "3.8.4"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omegajail"
-version = "3.8.4"
+version = "3.11.3"
 description = "The omegaUp sandbox"
 license = "BSD"
 repository = "https://github.com/omegaup/omegajail"

--- a/Dockerfile.distrib
+++ b/Dockerfile.distrib
@@ -36,6 +36,7 @@ RUN mkdir /src
 WORKDIR /src
 
 COPY README.md ./
+COPY build.rs ./
 COPY Cargo.lock ./
 COPY Cargo.toml ./
 COPY ./src/ ./src/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ POLICY_SIGSYS_BINARIES := $(addprefix out/policies/sigsys/,$(patsubst %.policy,%
 
 MKROOT_SOURCE_FILES := Dockerfile.rootfs tools/mkroot tools/java.base.aotcfg \
                        tools/Main.runtimeconfig.json tools/Release.rsp
+RUST_SOURCE_FILES := Cargo.lock Cargo.toml build.rs $(shell find src/ -name '*.rs')
 OMEGAJAIL_RELEASE ?= $(shell git describe --tags)
 DESTDIR ?= /var/lib/omegajail
 
@@ -23,11 +24,11 @@ out/policies/sigsys: out/policies
 minijail/constants.json:
 	$(MAKE) OUT=${PWD}/minijail -C minijail constants.json
 
-out/bin/omegajail: $(shell find src/ -name '*.rs') | out/bin
+out/bin/omegajail: $(RUST_SOURCE_FILES) | out/bin
 	cargo build --release --bin=omegajail
 	cp target/release/omegajail $@
 
-out/bin/java-compile: src/java_compile.rs | out/bin
+out/bin/java-compile: $(RUST_SOURCE_FILES) | out/bin
 	cargo build --release --bin=java-compile
 	cp target/release/java-compile $@
 
@@ -131,7 +132,7 @@ omegajail-jammy-rootfs-x86_64.tar.xz: .omegajail-builder-rootfs-build.stamp
 		/var/lib/omegajail/ && \
 		mv ".$@.tmp" "$@" || rm ".$@.tmp"
 
-.omegajail-builder-distrib.stamp: Dockerfile.distrib $(wildcard src/*.rs src/jail/*.rs tools/omegajail-setup policies/*.frequency policies/*.policy)
+.omegajail-builder-distrib.stamp: Dockerfile.distrib $(RUST_SOURCE_FILES) tools/omegajail-setup $(wildcard policies/*.frequency policies/*.policy)
 	docker build \
 		--build-arg OMEGAJAIL_RELEASE=$(OMEGAJAIL_RELEASE) \
 		-t omegaup/omegajail-builder-distrib \

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,36 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=OMEGAJAIL_RELEASE");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+    println!("cargo:rerun-if-changed=.git/packed-refs");
+
+    let version = env::var("OMEGAJAIL_RELEASE")
+        .ok()
+        .filter(|version| !version.trim().is_empty())
+        .or_else(git_describe)
+        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION is set"));
+
+    println!("cargo:rustc-env=OMEGAJAIL_VERSION={version}");
+}
+
+fn git_describe() -> Option<String> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let version = String::from_utf8(output.stdout).ok()?;
+    let version = version.trim();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version.to_owned())
+    }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -53,7 +53,13 @@ pub enum Language {
 
 /// [`clap`](::clap) arguments for the sandboxing.
 #[derive(Parser, Clone, Debug)]
-#[clap(author, version, about, long_about = None, trailing_var_arg(true))]
+#[clap(
+    author,
+    version = env!("OMEGAJAIL_VERSION"),
+    about,
+    long_about = None,
+    trailing_var_arg(true)
+)]
 #[clap(group(ArgGroup::new("run_mode").required(true).args(&["compile", "run"])))]
 pub struct Args {
     /// Root of the omegajail runtime

--- a/src/java_compile.rs
+++ b/src/java_compile.rs
@@ -22,7 +22,12 @@ enum Language {
 }
 
 #[derive(Parser, Clone, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[clap(
+    author,
+    version = env!("OMEGAJAIL_VERSION"),
+    about,
+    long_about = None
+)]
 struct Args {
     /// The language in which to compile
     #[clap(long, arg_enum, value_name = "LANGUAGE", default_value = "java")]


### PR DESCRIPTION
## Summary

Fix the Rust binary version metadata used by `omegajail --version`.

The Rust rewrite left the crate version at `3.8.4`, while repository releases had advanced to `v3.11.x`. This made release artifacts report an obsolete binary version.

This change adds a small `build.rs` that sets `OMEGAJAIL_VERSION` from:

1. `OMEGAJAIL_RELEASE`, when provided by the release workflow / Makefile
2. `git describe --tags --always --dirty`, for local builds
3. `CARGO_PKG_VERSION`, as a final fallback

It also updates the package version to `3.11.3`, wires clap to use `OMEGAJAIL_VERSION`, and makes the Makefile/Docker release path depend on `build.rs` and Cargo metadata.

Fixes: #67 

## Validation

- `cargo fmt --check`
- `cargo check --locked`
- `cargo test --no-run`
- `timeout 180s cargo test -- --skip 'jail::tests::'`
- `git diff --check`
- `OMEGAJAIL_RELEASE=v9.9.9 cargo run --quiet --bin omegajail -- --version`
- `make OMEGAJAIL_RELEASE=v9.9.9 out/bin/omegajail out/bin/java-compile`
- `./out/bin/omegajail --version`

Validated output:

- `omegajail v9.9.9`