### PR TITLE
Quiet Java AOT skip log on Jammy

### DIFF
--- a/tools/mkroot
+++ b/tools/mkroot
@@ -594,7 +594,10 @@ def _main() -> None:
                 f'{root.path}/kotlin-stdlib.jar.so',
             ])
         else:
-            logging.info('Skipping Java AOT generation; /usr/bin/jaotc is unavailable.')
+            # OpenJDK 17 no longer ships jaotc, so Jammy builds normally skip
+            # these optional AOT artifacts.
+            logging.debug(
+                'Skipping Java AOT generation; /usr/bin/jaotc is unavailable.')
 
     with Chroot(
             os.path.join(args.target, 'root-python2'), PYTHON2_ROOT,


### PR DESCRIPTION
## Summary

Quiet the Java AOT skip message during Jammy rootfs builds.

OpenJDK 17 no longer ships `jaotc`, so Ubuntu 22.04/Jammy builds normally skip Java AOT artifact generation. This is expected and not a build failure.

The message is now logged at debug level instead of info level.

Fixes: #72 