### PR TITLE
Add Karel runtime mountpoints to rootfs

### DIFF
--- a/tools/mkroot
+++ b/tools/mkroot
@@ -454,6 +454,8 @@ def _main() -> None:
         root.mkdir(HASKELL_ROOT)
         root.mkdir(DOTNET_ROOT)
         root.mkdir(JS_ROOT)
+        root.mkdir(KARELJS_ROOT)
+        root.mkdir(REKAREL_ROOT)
         root.mkdir(RUST_ROOT)
         root.mkdir(GO_ROOT)
 


### PR DESCRIPTION
## Summary

Add `/opt/kareljs` and `/opt/rekarel` as rootfs mountpoints.

This completes the runtime-root split from #76 by ensuring the new Karel/ReKarel bind mount targets exist in both normal and compiler rootfs layouts.

## Validation

- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile tools/mkroot`
- `make .omegajail-builder-rootfs-setup.stamp`
- Generated a temporary rootfs and verified:
  - `root/opt/kareljs`
  - `root/opt/rekarel`
  - `root-compilers/opt/kareljs`
  - `root-compilers/opt/rekarel`

Refs #76